### PR TITLE
fix docker-verify-refreshed-at-updated workflow

### DIFF
--- a/.github/workflows/docker-verify-refreshed-at-updated.yaml
+++ b/.github/workflows/docker-verify-refreshed-at-updated.yaml
@@ -1,7 +1,12 @@
-name: Verify Dockerfile REFRESHED_AT Updated
+name: Docker verify REFRESHED_AT Updated
 
 on:
   pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 permissions: {}
 


### PR DESCRIPTION
Add pull-requests: read permission to docker-verify-refreshed-at-updated.yaml and remove incorrectly named verify-dockerfile-refreshed-at-updated.yaml.