### PR TITLE
#52 CI maintenance: clean up cspell.json and Slack notification wiring

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -6,8 +6,6 @@ permissions: {}
 
 jobs:
   pylint:
-    outputs:
-      status: ${{ job.status }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -37,10 +35,10 @@ jobs:
 
   slack-notification:
     needs: [pylint]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.pylint.outputs.status ) && github.ref_name == github.event.repository.default_branch }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.pylint.result ) && github.ref_name == github.event.repository.default_branch }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.pylint.outputs.status }}
+      job-status: ${{ needs.pylint.result }}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -15,7 +15,6 @@
     "cooldown",
     "Dlalas",
     "dockerfiles",
-    "esbenp",
     "fstring",
     "HAUPTMAN",
     "ICLA",


### PR DESCRIPTION
## Summary
- Remove unused words from `.vscode/cspell.json`
- Use `needs.<job>.result` instead of `needs.<job>.outputs.status` for Slack notifications

Closes #52

---

Resolves #52